### PR TITLE
AMBARI-25545

### DIFF
--- a/contrib/views/files/src/main/java/org/apache/ambari/view/filebrowser/DownloadService.java
+++ b/contrib/views/files/src/main/java/org/apache/ambari/view/filebrowser/DownloadService.java
@@ -62,6 +62,7 @@ import java.util.Queue;
 import java.util.UUID;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+import java.net.URLEncoder;
 
 /**
  * Service for download and aggregate files
@@ -228,7 +229,7 @@ public class DownloadService extends HdfsService {
         }
       };
       return Response.ok(result)
-          .header("Content-Disposition", "inline; filename=\"" + name +"\"").build();
+          .header("Content-Disposition", "inline; filename=\"" + URLEncoder.encode(name, "UTF-8") +"\"").build();
     } catch (WebApplicationException ex) {
       LOG.error("Error occurred : ",ex);
       throw ex;


### PR DESCRIPTION
If the file directory name in HDFS contains non-ASCII characters, the zip file name generated by downloading will be displayed incorrectly

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Ambari Contributing Guide](https://cwiki.apache.org/confluence/display/AMBARI/How+to+Contribute) before opening a pull request.